### PR TITLE
Ignore -svn suffix in pkgname

### DIFF
--- a/gendesk.1
+++ b/gendesk.1
@@ -47,7 +47,7 @@ Supported environment variables:
 A package name must be given, either by specifying a PKGBUILD file, using
 \-\-pkgname or by defining a $pkgname environment variable.
 .sp
-Note that the "-git" suffix in package names will be ignored, if present.
+Note that the "-git" or "-svn" suffix in package names will be ignored, if present.
 .PP
 .SH OPTIONS
 .TP

--- a/main.go
+++ b/main.go
@@ -315,8 +315,8 @@ func main() {
 			// Don't bother if it's a -nox or -cli package
 			continue
 		}
-		// Strip the "-git" suffix, if present
-		if strings.HasSuffix(pkgname, "-git") {
+		// Strip the "-git" or "-svn" suffix, if present
+		if strings.HasSuffix(pkgname, "-git") || strings.HasSuffix(pkgname, "-svn") {
 			pkgname = pkgname[:len(pkgname)-4]
 		}
 		// TODO: Find a better way for all the if checks below


### PR DESCRIPTION
Hi, I use gendesk in a `-svn` package and since it's already done for `-git` I thought it would be nice to have for `-svn` packages as well.