### PR TITLE
Fix -hg suffix

### DIFF
--- a/gendesk.1
+++ b/gendesk.1
@@ -47,7 +47,7 @@ Supported environment variables:
 A package name must be given, either by specifying a PKGBUILD file, using
 \-\-pkgname or by defining a $pkgname environment variable.
 .sp
-Note that the "-git" or "-svn" suffix in package names will be ignored, if present.
+Note that the "-git", "-svn" or "-hg" suffix in package names will be ignored, if present.
 .PP
 .SH OPTIONS
 .TP

--- a/main.go
+++ b/main.go
@@ -335,8 +335,10 @@ func main() {
 			continue
 		}
 		// Strip the "-git", "-svn" or "-hg" suffix, if present
-		if strings.HasSuffix(pkgname, "-git") || strings.HasSuffix(pkgname, "-svn") || strings.HasSuffix(pkgname, "-hg") {
+		if strings.HasSuffix(pkgname, "-git") || strings.HasSuffix(pkgname, "-svn") {
 			pkgname = pkgname[:len(pkgname)-4]
+		} else if strings.HasSuffix(pkgname, "-hg") {
+			pkgname = pkgname[:len(pkgname)-3]
 		}
 		// TODO: Find a better way for all the if checks below
 		pkgdesc, found := pkgdescMap[pkgname]


### PR DESCRIPTION
Stripping the `-hg` suffix from package name (if provided via --pkgname) removed 4 chars instead of 3.
Fixed that and also updated the man page.